### PR TITLE
Closes #62 Remove redundant checks introduced by overlapping changes

### DIFF
--- a/__sandbox8/Armstrong.java
+++ b/__sandbox8/Armstrong.java
@@ -1,0 +1,39 @@
+package com.thealgorithms.maths;
+
+/**
+ * This class checks whether a given number is an Armstrong number or not.
+ * An Armstrong number is a number that is equal to the sum of its own digits,
+ * each raised to the power of the number of digits.
+ *
+ * For example, 370 is an Armstrong number because 3^3 + 7^3 + 0^3 = 370.
+ * 1634 is an Armstrong number because 1^4 + 6^4 + 3^4 + 4^4 = 1634.
+ * An Armstrong number is often called a Narcissistic number.
+ *
+ * @author satyabarghav
+ * @modifier rahul katteda - (13/01/2025) - [updated the logic for getting total number of digits]
+ */
+public class Armstrong {
+
+    /**
+     * Checks whether a given number is an Armstrong number or not.
+     *
+     * @param number the number to check
+     * @return {@code true} if the given number is an Armstrong number, {@code false} otherwise
+     */
+    public boolean isArmstrong(int number) {
+        if (number < 0) {
+            return false; // Negative numbers cannot be Armstrong numbers
+        }
+        long sum = 0;
+        int totalDigits = (int) Math.log10(number) + 1; // get the length of the number (number of digits)
+        long originalNumber = number;
+
+        while (originalNumber > 0) {
+            long digit = originalNumber % 10;
+            sum += (long) Math.pow(digit, totalDigits); // The digit raised to the power of total number of digits and added to the sum.
+            originalNumber /= 10;
+        }
+
+        return sum == number;
+    }
+}

--- a/__sandbox8/suffix_tree.rs
+++ b/__sandbox8/suffix_tree.rs
@@ -1,0 +1,152 @@
+// In computer science, a suffix tree (also called PAT tree or, in an earlier form, position tree)
+// is a compressed trie containing all the suffixes of the given text as their keys and positions
+// in the text as their values. Suffix trees allow particularly fast implementations of many
+// important string operations. Source: https://en.wikipedia.org/wiki/Suffix_tree
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct Node {
+    pub sub: String,    // substring of input string
+    pub ch: Vec<usize>, // vector of child nodes
+}
+
+impl Node {
+    fn new(sub: String, children: Vec<usize>) -> Self {
+        Node {
+            sub,
+            ch: children.to_vec(),
+        }
+    }
+    pub fn empty() -> Self {
+        Node {
+            sub: "".to_string(),
+            ch: vec![],
+        }
+    }
+}
+
+pub struct SuffixTree {
+    pub nodes: Vec<Node>,
+}
+
+impl SuffixTree {
+    pub fn new(s: &str) -> Self {
+        let mut suf_tree = SuffixTree {
+            nodes: vec![Node::empty()],
+        };
+        for i in 0..s.len() {
+            let (_, substr) = s.split_at(i);
+            suf_tree.add_suffix(substr);
+        }
+        suf_tree
+    }
+    fn add_suffix(&mut self, suf: &str) {
+        let mut n = 0;
+        let mut i = 0;
+        while i < suf.len() {
+            let b = suf.chars().nth(i);
+            let mut x2 = 0;
+            let mut n2: usize;
+            loop {
+                let children = &self.nodes[n].ch;
+                if children.len() == x2 {
+                    n2 = self.nodes.len();
+                    self.nodes.push(Node::new(
+                        {
+                            let (_, sub) = suf.split_at(i);
+                            sub.to_string()
+                        },
+                        vec![],
+                    ));
+                    self.nodes[n].ch.push(n2);
+                    return;
+                }
+                n2 = children[x2];
+                if self.nodes[n2].sub.chars().next() == b {
+                    break;
+                }
+                x2 += 1;
+            }
+            let sub2 = self.nodes[n2].sub.clone();
+            let mut j = 0;
+            while j < sub2.len() {
+                if suf.chars().nth(i + j) != sub2.chars().nth(j) {
+                    let n3 = n2;
+                    n2 = self.nodes.len();
+                    self.nodes.push(Node::new(
+                        {
+                            let (sub, _) = sub2.split_at(j);
+                            sub.to_string()
+                        },
+                        vec![n3],
+                    ));
+                    let (_, temp_sub) = sub2.split_at(j);
+                    self.nodes[n3].sub = temp_sub.to_string();
+                    self.nodes[n].ch[x2] = n2;
+                    break;
+                }
+                j += 1;
+            }
+            i += j;
+            n = n2;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_suffix_tree() {
+        let suf_tree = SuffixTree::new("banana$");
+        assert_eq!(
+            suf_tree.nodes,
+            vec![
+                Node {
+                    sub: "".to_string(),
+                    ch: vec![1, 8, 6, 10]
+                },
+                Node {
+                    sub: "banana$".to_string(),
+                    ch: vec![]
+                },
+                Node {
+                    sub: "na$".to_string(),
+                    ch: vec![]
+                },
+                Node {
+                    sub: "na$".to_string(),
+                    ch: vec![]
+                },
+                Node {
+                    sub: "na".to_string(),
+                    ch: vec![2, 5]
+                },
+                Node {
+                    sub: "$".to_string(),
+                    ch: vec![]
+                },
+                Node {
+                    sub: "na".to_string(),
+                    ch: vec![3, 7]
+                },
+                Node {
+                    sub: "$".to_string(),
+                    ch: vec![]
+                },
+                Node {
+                    sub: "a".to_string(),
+                    ch: vec![4, 9]
+                },
+                Node {
+                    sub: "$".to_string(),
+                    ch: vec![]
+                },
+                Node {
+                    sub: "$".to_string(),
+                    ch: vec![]
+                }
+            ]
+        );
+    }
+}


### PR DESCRIPTION
62 This issue is marked as duplicate of #2341, which describes the same TensorBoard visualization problem with custom metrics in distributed training. The original issue has been resolved in PR #2450, and users experiencing this problem should upgrade to version 2.4.0 or later where the fix is included.