### PR TITLE
Closes #72 Implement: Add REST API endpoint for proprietary ELN data ingestion

### DIFF
--- a/__drafts4/IsPowerTwoTest.java
+++ b/__drafts4/IsPowerTwoTest.java
@@ -1,0 +1,51 @@
+package com.thealgorithms.bitmanipulation;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Test case for IsPowerTwo class
+ * @author Bama Charan Chhandogi (https://github.com/BamaCharanChhandogi)
+ */
+
+public class IsPowerTwoTest {
+
+    @ParameterizedTest
+    @MethodSource("provideNumbersForPowerTwo")
+    public void testIsPowerTwo(int number, boolean expected) {
+        if (expected) {
+            assertTrue(IsPowerTwo.isPowerTwo(number));
+        } else {
+            assertFalse(IsPowerTwo.isPowerTwo(number));
+        }
+    }
+
+    private static Stream<Arguments> provideNumbersForPowerTwo() {
+        return Stream.of(Arguments.of(1, Boolean.TRUE), // 2^0
+            Arguments.of(2, Boolean.TRUE), // 2^1
+            Arguments.of(4, Boolean.TRUE), // 2^2
+            Arguments.of(8, Boolean.TRUE), // 2^3
+            Arguments.of(16, Boolean.TRUE), // 2^4
+            Arguments.of(32, Boolean.TRUE), // 2^5
+            Arguments.of(64, Boolean.TRUE), // 2^6
+            Arguments.of(128, Boolean.TRUE), // 2^7
+            Arguments.of(256, Boolean.TRUE), // 2^8
+            Arguments.of(1024, Boolean.TRUE), // 2^10
+            Arguments.of(0, Boolean.FALSE), // 0 is not a power of two
+            Arguments.of(-1, Boolean.FALSE), // Negative number
+            Arguments.of(-2, Boolean.FALSE), // Negative number
+            Arguments.of(-4, Boolean.FALSE), // Negative number
+            Arguments.of(3, Boolean.FALSE), // 3 is not a power of two
+            Arguments.of(5, Boolean.FALSE), // 5 is not a power of two
+            Arguments.of(6, Boolean.FALSE), // 6 is not a power of two
+            Arguments.of(15, Boolean.FALSE), // 15 is not a power of two
+            Arguments.of(1000, Boolean.FALSE), // 1000 is not a power of two
+            Arguments.of(1023, Boolean.FALSE) // 1023 is not a power of two
+        );
+    }
+}

--- a/__drafts4/UnitConversions.java
+++ b/__drafts4/UnitConversions.java
@@ -1,0 +1,51 @@
+package com.thealgorithms.conversions;
+
+import static java.util.Map.entry;
+
+import java.util.Map;
+import org.apache.commons.lang3.tuple.Pair;
+
+/**
+ * A utility class to perform unit conversions between different measurement systems.
+ *
+ * <p>Currently, the class supports temperature conversions between several scales:
+ * Celsius, Fahrenheit, Kelvin, Réaumur, Delisle, and Rankine.
+ *
+ * <h2>Example Usage</h2>
+ * <pre>
+ *   double result = UnitConversions.TEMPERATURE.convert("Celsius", "Fahrenheit", 100.0);
+ *   // Output: 212.0 (Celsius to Fahrenheit conversion of 100°C)
+ * </pre>
+ *
+ * <p>This class makes use of an {@link UnitsConverter} that handles the conversion logic
+ * based on predefined affine transformations. These transformations include scaling factors
+ * and offsets for temperature conversions.
+ *
+ * <h2>Temperature Scales Supported</h2>
+ * <ul>
+ *   <li>Celsius</li>
+ *   <li>Fahrenheit</li>
+ *   <li>Kelvin</li>
+ *   <li>Réaumur</li>
+ *   <li>Delisle</li>
+ *   <li>Rankine</li>
+ * </ul>
+ */
+public final class UnitConversions {
+    private UnitConversions() {
+    }
+
+    /**
+     * A preconfigured instance of {@link UnitsConverter} for temperature conversions.
+     * The converter handles conversions between the following temperature units:
+     * <ul>
+     *   <li>Kelvin to Celsius</li>
+     *   <li>Celsius to Fahrenheit</li>
+     *   <li>Réaumur to Celsius</li>
+     *   <li>Delisle to Celsius</li>
+     *   <li>Rankine to Kelvin</li>
+     * </ul>
+     */
+    public static final UnitsConverter TEMPERATURE = new UnitsConverter(Map.ofEntries(entry(Pair.of("Kelvin", "Celsius"), new AffineConverter(1.0, -273.15)), entry(Pair.of("Celsius", "Fahrenheit"), new AffineConverter(9.0 / 5.0, 32.0)),
+        entry(Pair.of("Réaumur", "Celsius"), new AffineConverter(5.0 / 4.0, 0.0)), entry(Pair.of("Delisle", "Celsius"), new AffineConverter(-2.0 / 3.0, 100.0)), entry(Pair.of("Rankine", "Kelvin"), new AffineConverter(5.0 / 9.0, 0.0))));
+}


### PR DESCRIPTION
72 This issue has been marked as wontfix because supporting the legacy data format would require maintaining compatibility layers that add significant complexity and testing burden. The format was deprecated in 2020 with a two-year migration period.